### PR TITLE
Revert mapping of Segment lifecycle events

### DIFF
--- a/Sources/Segment-Appcues/AppcuesDestination.swift
+++ b/Sources/Segment-Appcues/AppcuesDestination.swift
@@ -22,13 +22,6 @@ public class AppcuesDestination: DestinationPlugin {
 
     public private(set) var appcues: Appcues?
 
-    private let eventMapping = [
-        "Application Installed": "appcues:application_installed",
-        "Application Opened": "appcues:application_opened",
-        "Application Updated": "appcues:application_updated",
-        "Application Backgrounded": "appcues:application_backgrounded",
-    ]
-
     public init() { }
 
     public func update(settings: Settings, type: UpdateType) {
@@ -45,9 +38,7 @@ public class AppcuesDestination: DestinationPlugin {
 
     public func track(event: TrackEvent) -> TrackEvent? {
         if let appcues = appcues {
-            let segmentEventName = event.event
-            let eventName = eventMapping[segmentEventName] ?? segmentEventName
-            appcues.track(name: eventName, properties: event.properties?.appcuesProperties)
+            appcues.track(name: event.event, properties: event.properties?.appcuesProperties)
         }
         return event
     }


### PR DESCRIPTION
I don't think we want this any longer, as the Appcues SDK now manages the session events internally regardless.  Extra stuff like this from Segment should just be allowed to pass through and be recorded like any other event.