### PR TITLE
Updates for Appcues 1.1

### DIFF
--- a/Examples/SegmentDestinationExample/SegmentDestinationExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/SegmentDestinationExample/SegmentDestinationExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "Segment",
-        "repositoryURL": "https://github.com/segmentio/analytics-swift.git",
+        "repositoryURL": "https://github.com/segmentio/analytics-swift",
         "state": {
           "branch": null,
-          "revision": "8ae3136bffaa139a690e7841bf63143605041540",
-          "version": "1.3.0"
+          "revision": "939a04164cd4db7ca666dd1e09663edc2d34c4f3",
+          "version": "1.3.3"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/appcues/appcues-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "f70c0b108b33e4b0caf8706ceca2eeafe8d3200d",
-          "version": "1.0.0-beta.3"
+          "revision": "818c49e4ad24be61c4848b9728608d45fd46f30e",
+          "version": "1.1.0"
         }
       },
       {

--- a/Sources/SegmentAppcues/AppcuesDestination.swift
+++ b/Sources/SegmentAppcues/AppcuesDestination.swift
@@ -50,14 +50,14 @@ public class AppcuesDestination: DestinationPlugin {
     }
 
     public func track(event: TrackEvent) -> TrackEvent? {
-        if let appcues = appcues, !event.event.isEmpty {
+        if let appcues = appcues, event.isValid {
             appcues.track(name: event.event, properties: event.properties?.appcuesProperties)
         }
         return event
     }
 
     public func screen(event: ScreenEvent) -> ScreenEvent? {
-        if let appcues = appcues, let title = event.name, !title.isEmpty {
+        if let appcues = appcues, let title = event.title {
             appcues.screen(title: title, properties: event.properties?.appcuesProperties)
         }
         return event
@@ -73,6 +73,23 @@ public class AppcuesDestination: DestinationPlugin {
     public func reset() {
         guard let appcues = appcues else { return }
         appcues.reset()
+    }
+}
+
+private extension TrackEvent {
+    var isValid: Bool {
+        // not a valid appcues event if the name is empty, or if it is re-tracking an internal event
+        // prefixed with "appcues:"
+        !event.isEmpty && !event.lowercased().starts(with: "appcues:")
+    }
+}
+
+private extension ScreenEvent {
+    var title: String? {
+        // return the valid appcues screen, if available, or nil. If the screen title is nil or empty, or
+        // is retracking an internal screen event prefixed with "appcues:", it is ignored
+        guard let title = name, !title.isEmpty && !title.lowercased().starts(with: "appcues:") else { return nil }
+        return title
     }
 }
 

--- a/Sources/SegmentAppcues/AppcuesDestination.swift
+++ b/Sources/SegmentAppcues/AppcuesDestination.swift
@@ -30,11 +30,16 @@ public class AppcuesDestination: DestinationPlugin {
     }
 
     public func update(settings: Settings, type: UpdateType) {
-        guard let appcuesSettings: AppcuesSettings = settings.integrationSettings(forPlugin: self) else { return }
+        guard let appcuesSettings: AppcuesSettings = settings.integrationSettings(forPlugin: self) else {
+            analytics?.log(message: "\(key) destination is disabled via settings")
+            return
+        }
         let config = Appcues.Config(accountID: appcuesSettings.accountId, applicationID: appcuesSettings.applicationId)
             .apply(configuration)
+            .additionalAutoProperties(["_segmentVersion": analytics?.version() ?? "unknown"])
 
         appcues = Appcues(config: config)
+        analytics?.log(message: "\(key) destination loaded")
     }
 
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {


### PR DESCRIPTION
[sc-43567]

These are the updates to the Segment Plugin for iOS to correspond with the native SDK 1.1 update that was just released.
* Add `_segmentVersion` auto property
* Improve logging
* Avoid re-ingesting internal appcues:* prefix events