### PR TITLE
Update Appcues dependency version to be a minimum 1.3.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(name: "Segment", url: "https://github.com/segmentio/analytics-swift.git" , from: "1.0.0"),
-        .package(name: "Appcues" , url: "https://github.com/appcues/appcues-ios-sdk.git", from: "1.2.0"),
+        .package(name: "Appcues" , url: "https://github.com/appcues/appcues-ios-sdk.git", from: "1.3.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
getting this update prepped for the upcoming 1.3.0 iOS release