### PR TITLE
Guard against initializing Appcues multiple times

### DIFF
--- a/Sources/SegmentAppcues/AppcuesDestination.swift
+++ b/Sources/SegmentAppcues/AppcuesDestination.swift
@@ -30,6 +30,8 @@ public class AppcuesDestination: DestinationPlugin {
     }
 
     public func update(settings: Settings, type: UpdateType) {
+        guard type == .initial else { return }
+
         guard let appcuesSettings: AppcuesSettings = settings.integrationSettings(forPlugin: self) else {
             analytics?.log(message: "\(key) destination is disabled via settings")
             return


### PR DESCRIPTION
The `update(settings: Settings, type: UpdateType)` plugin function can get called multiple times with refreshes - specifically when the application returns from the background. We do not want to re-initialize Appcues each time and start new sessions - which could trigger unexpected additional flows. Guard against multiple init by only initializing the appcues reference when the `UpdateType` is `.initial`. This is similar to what is done on the Android plugin here https://github.com/appcues/segment-appcues-android/blob/main/segment-appcues/src/main/java/com/appcues/segment/AppcuesDestination.kt#L51.